### PR TITLE
Convert erlang IOList to string before encoding

### DIFF
--- a/lib/logger/backends/json_event.ex
+++ b/lib/logger/backends/json_event.ex
@@ -38,7 +38,7 @@ defmodule Logger.Backends.JSON.Event do
     |> NaiveDateTime.to_iso8601
   end
 
-  defp normalize_message(txt) when is_list(txt), do: inspect(txt)
+  defp normalize_message(txt) when is_list(txt), do: to_string(txt)
   defp normalize_message(txt) when is_bitstring(txt), do: txt
   defp normalize_message(_), do: "unsupported message type"
 end

--- a/test/logger/backends/json_test.exs
+++ b/test/logger/backends/json_test.exs
@@ -127,13 +127,13 @@ defmodule Logger.Backends.JSONTest do
 
     assert msg["error_logger"] == "progress"
     assert msg["level"] == "info"
-    assert msg["message"] =~ "[\"Child \", \"Logger.ErrorHandler\", \" of Supervisor \", \"Logger.Supervisor\", \" started\""
+    assert msg["message"] =~ "Child Logger.ErrorHandler of Supervisor Logger.Supervisor started"
 
     [msg | rest] = rest
 
     assert msg["error_logger"] == "progress"
     assert msg["level"] == "info"
-    assert msg["message"] =~ "[\"Application \", \"logger\", \" started at \""
+    assert msg["message"] =~ "Application logger started at "
 
     [msg] = rest
 


### PR DESCRIPTION
Hi and thanks for creating logger_backends_json!

This change allows logs in the form of IOList to be output as regular string.

Logs from the Phoenix framework were being output as: 

```JSON
{
"message": "[\"Sent\", 32, \"200\", \" in \", [\"11\", \"ms\"]]"
}
```

but should now appear as

```JSON
{
"message": "Sent 200 in 11 ms"
}
```

Is there a particular reason for using `inspect` originally?

